### PR TITLE
Serve dataset through Vite public directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ export default defineConfig(() => ({
   base: process.env.GITHUB_REPOSITORY
     ? `/${process.env.GITHUB_REPOSITORY.split('/')[1]}/`
     : '/',
+  publicDir: 'data',
 }));


### PR DESCRIPTION
## Summary
- configure Vite to treat the data folder as its public directory so the alcohol.csv asset is available at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6af1172148327be721f0d547415ca